### PR TITLE
ci: add tiered pre-publish runtime gate with real-Azure certification

### DIFF
--- a/.github/workflows/e2e-azure.yml
+++ b/.github/workflows/e2e-azure.yml
@@ -1,12 +1,21 @@
 name: e2e-azure
 
+# Deploys the candidate to REAL Azure, runs live e2e, and (on success) records a
+# certification artifact keyed by commit SHA + version. publish-pypi.yml's
+# verify-azure-certification gate requires a fresh, matching certification before
+# any PyPI upload. This is a per-release certification, not a per-publish job:
+# it no longer triggers on tag push (that raced publish and could not gate it).
 on:
   workflow_dispatch:
-  schedule:
-    - cron: "0 6 * * 1"  # Weekly on Monday 6:00 UTC
-  push:
-    tags:
-      - "v*"
+    inputs:
+      ref:
+        description: Git ref (branch/tag/SHA) of the release commit to certify
+        required: false
+        type: string
+      version:
+        description: Expected package version (must match source __version__)
+        required: false
+        type: string
 
 permissions:
   id-token: write
@@ -46,6 +55,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v6
+        with:
+          ref: ${{ inputs.ref || github.ref }}
 
       - name: Compute resource names
         id: names
@@ -126,6 +137,39 @@ jobs:
         run: pytest tests/e2e -v -m azure_e2e --no-cov --html=e2e-report/report.html --self-contained-html
         env:
           E2E_BASE_URL: https://${{ steps.names.outputs.app }}.azurewebsites.net
+
+      - name: Record certification
+        run: |
+          SHA=$(git rev-parse HEAD)
+          FILE_VERSION=$(grep -Po '(?<=__version__ = ")[^"]*' src/azure_functions_db/__init__.py)
+          REQ_VERSION="${{ inputs.version }}"
+          if [ -n "$REQ_VERSION" ] && [ "$REQ_VERSION" != "$FILE_VERSION" ]; then
+            echo "::error ::Requested certification version ($REQ_VERSION) != source version ($FILE_VERSION)"
+            exit 1
+          fi
+          VERSION="${REQ_VERSION:-$FILE_VERSION}"
+          mkdir -p cert
+          cat > cert/certification.json <<EOF
+          {
+            "package": "azure-functions-db",
+            "version": "$VERSION",
+            "commit": "$SHA",
+            "ref": "${{ inputs.ref || github.ref }}",
+            "workflow": "e2e-azure.yml",
+            "run_id": "${{ github.run_id }}",
+            "result": "success",
+            "certified_at": "$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+          }
+          EOF
+          cat cert/certification.json
+
+      - name: Upload certification record
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        with:
+          name: azure-cert
+          path: cert/
+          if-no-files-found: error
+          retention-days: 30
 
       - name: Upload e2e report
         if: always()

--- a/.github/workflows/publish-pypi.yml
+++ b/.github/workflows/publish-pypi.yml
@@ -2,6 +2,7 @@ name: Publish to PyPI
 
 on:
   push:
+    # Trigger the workflow on tag pushes matching v* (e.g., v1.0.0)
     tags:
       - 'v*'
   workflow_dispatch:
@@ -13,13 +14,31 @@ on:
 
 permissions:
   contents: read
-  id-token: write
 
+# Verify-before-publish gate (see AGENTS.md):
+#   build -> lib-tests -> db-runtime-gate -> verify-azure-certification -> publish
+# Tiered runtime verification before any PyPI upload:
+#   * lib-tests             : the library's own unit suite.
+#   * db-runtime-gate       : install the candidate wheel, assert the installed
+#                             version matches the release, then boot Azurite and run
+#                             the package-native BlobCheckpointStore live integration
+#                             test. Unlike a host-boot smoke, this actually imports and
+#                             exercises this package's primary runtime surface against a
+#                             real storage backend (no cloud).
+#   * verify-azure-certification : requires the EXACT release commit to have passed a
+#                             real-Azure deploy+live-e2e certification (e2e-azure.yml)
+#                             that is fresh and version/SHA-matched. Real Azure is
+#                             certified per release, not per publish.
+# The publish job uploads the EXACT artifact that was tested; it never rebuilds.
+# A tag whose gate fails is a failed release candidate: the version stays
+# unpublished. Recover by fixing forward and cutting the next patch tag
+# (never move a tag that may already have been consumed).
 jobs:
-  build-and-publish:
+  build:
+    name: Build & verify version
     runs-on: ubuntu-latest
-    environment: pypi
-
+    outputs:
+      version: ${{ steps.version.outputs.version }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v6
@@ -34,14 +53,10 @@ jobs:
       - name: Install build dependencies
         run: |
           python -m pip install --upgrade pip
-
-      - name: Run lightweight tests
-        run: |
-          pip install hatch
-          pip install -e ".[dev]"
-          pytest -v -m "not integration and not azurite and not host_e2e and not azure_e2e" --no-cov --maxfail=3 --disable-warnings
+          pip install build
 
       - name: Check if tag matches __version__
+        id: version
         run: |
           TAG_NAME="${{ github.event_name == 'workflow_dispatch' && inputs.tag || github.ref_name }}"
           VERSION_FROM_FILE=$(grep -Po '(?<=__version__ = ")[^"]*' src/azure_functions_db/__init__.py)
@@ -53,11 +68,191 @@ jobs:
             echo "::error ::Version in __init__.py ($VERSION_FROM_FILE) does not match git tag ($TAG_VERSION)"
             exit 1
           fi
+          echo "version=$TAG_VERSION" >> "$GITHUB_OUTPUT"
 
       - name: Build distribution packages
+        run: python -m build
+
+      - name: Upload distribution artifact
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        with:
+          name: dist
+          path: dist/
+          if-no-files-found: error
+          retention-days: 5
+
+  lib-tests:
+    name: Library tests
+    needs: build
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v6
+        with:
+          ref: ${{ github.event_name == 'workflow_dispatch' && inputs.tag || github.ref }}
+
+      - name: Set up Python
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
+        with:
+          python-version: "3.12"
+
+      - name: Install Hatch
+        run: pip install hatch
+
+      - name: Run test suite
+        run: >-
+          hatch run pytest -v
+          -m "not integration and not azurite and not host_e2e and not azure_e2e"
+          --no-cov --maxfail=3 --disable-warnings
+
+  db-runtime-gate:
+    name: Package runtime gate (Azurite checkpoint live test, candidate wheel)
+    needs: build
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v6
+        with:
+          ref: ${{ github.event_name == 'workflow_dispatch' && inputs.tag || github.ref }}
+
+      - name: Set up Python
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
+        with:
+          python-version: "3.12"
+
+      - name: Start Azurite with skipApiVersionCheck
         run: |
-          pip install hatch
-          hatch build --clean
+          npm install -g azurite
+          azurite --skipApiVersionCheck --blobHost 0.0.0.0 --queueHost 0.0.0.0 --tableHost 0.0.0.0 &
+          sleep 3
+
+      - name: Install test tooling (no package yet)
+        run: |
+          pip install hatch pytest
+          # Blob SDK is required by the live checkpoint test surface.
+          pip install azure-storage-blob
+
+      - name: Download candidate wheel
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
+        with:
+          name: dist
+          path: candidate-dist
+
+      - name: Install candidate wheel
+        run: |
+          WHEEL=$(ls candidate-dist/*.whl | head -n1)
+          echo "Installing candidate wheel: $WHEEL"
+          pip install "${WHEEL}[all]"
+
+      - name: Verify candidate version is under test
+        run: |
+          EXPECTED="${{ needs.build.outputs.version }}"
+          ACTUAL=$(python -c "import importlib.metadata as m; print(m.version('azure-functions-db'))")
+          echo "Expected candidate version: $EXPECTED"
+          echo "Installed version:          $ACTUAL"
+          if [ "$EXPECTED" != "$ACTUAL" ]; then
+            echo "::error ::Runtime gate is not exercising the candidate wheel ($ACTUAL != $EXPECTED)"
+            exit 1
+          fi
+
+      - name: Run package-native Azurite checkpoint live test
+        env:
+          TEST_AZURITE_CONN_STR: "DefaultEndpointsProtocol=http;AccountName=devstoreaccount1;AccountKey=Eby8vdM02xNOcqFlqUwJPLlmEtlCDXJ1OUzFT50uSRZ6IFsuFq2UVErCz4I6tq/K1SZFPTOtr/KBHBeksoGMGw==;BlobEndpoint=http://127.0.0.1:10000/devstoreaccount1;"
+        run: |
+          pytest tests/integration/test_checkpoint_store_live.py \
+            -m "azurite" -v --no-cov --tb=short
+        timeout-minutes: 15
+
+  verify-azure-certification:
+    name: Verify Azure release certification
+    needs: build
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      actions: read
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v6
+        with:
+          ref: ${{ github.event_name == 'workflow_dispatch' && inputs.tag || github.ref }}
+
+      - name: Resolve release commit
+        id: commit
+        run: echo "sha=$(git rev-parse HEAD)" >> "$GITHUB_OUTPUT"
+
+      - name: Locate successful Azure certification for this commit
+        id: cert
+        env:
+          GH_TOKEN: ${{ github.token }}
+          GH_REPO: ${{ github.repository }}
+          COMMIT: ${{ steps.commit.outputs.sha }}
+        run: |
+          # A release may only publish if the EXACT commit was certified against
+          # real Azure by the trusted certification workflow (see e2e-azure.yml).
+          RUN_ID=$(gh run list \
+            --workflow e2e-azure.yml \
+            --json databaseId,headSha,conclusion \
+            --limit 50 \
+            --jq "[.[] | select(.headSha==\"$COMMIT\" and .conclusion==\"success\")] | first | .databaseId")
+          if [ -z "$RUN_ID" ] || [ "$RUN_ID" = "null" ]; then
+            echo "::error ::No successful Azure certification run found for commit $COMMIT. Dispatch the 'Azure Release Certification' (e2e-azure.yml) workflow on this release commit before publishing."
+            exit 1
+          fi
+          echo "Found certification run: $RUN_ID"
+          echo "run_id=$RUN_ID" >> "$GITHUB_OUTPUT"
+
+      - name: Download certification record
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
+        with:
+          name: azure-cert
+          path: cert
+          run-id: ${{ steps.cert.outputs.run_id }}
+          github-token: ${{ github.token }}
+
+      - name: Assert certification matches this release
+        env:
+          COMMIT: ${{ steps.commit.outputs.sha }}
+          VERSION: ${{ needs.build.outputs.version }}
+          FRESHNESS_DAYS: "14"
+        run: |
+          python3 - "$COMMIT" "$VERSION" "$FRESHNESS_DAYS" <<'PY'
+          import json, sys, datetime, pathlib
+          commit, version, fresh_days = sys.argv[1], sys.argv[2], int(sys.argv[3])
+          cert = json.loads(pathlib.Path("cert/certification.json").read_text())
+          def fail(m):
+              print(f"::error ::{m}")
+              sys.exit(1)
+          if cert.get("result") != "success":
+              fail("certification result is not success")
+          if cert.get("package") != "azure-functions-db":
+              fail(f"cert package {cert.get('package')} != azure-functions-db")
+          if cert.get("commit") != commit:
+              fail(f"cert commit {cert.get('commit')} != release commit {commit}")
+          if cert.get("version") != version:
+              fail(f"cert version {cert.get('version')} != release version {version}")
+          ts = cert.get("certified_at")
+          if not ts:
+              fail("cert missing certified_at")
+          certified = datetime.datetime.fromisoformat(ts.replace("Z", "+00:00"))
+          age = datetime.datetime.now(datetime.timezone.utc) - certified
+          if age > datetime.timedelta(days=fresh_days):
+              fail(f"certification is stale: {age.days}d > {fresh_days}d")
+          print(f"Azure certification verified: {version}@{commit[:12]} certified {age.days}d ago")
+          PY
+
+  publish:
+    name: Publish to PyPI
+    needs: [build, lib-tests, db-runtime-gate, verify-azure-certification]
+    runs-on: ubuntu-latest
+    environment: pypi
+    permissions:
+      id-token: write
+    steps:
+      - name: Download tested distribution artifact
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
+        with:
+          name: dist
+          path: dist
 
       - name: Publish to PyPI
         # Documented exception to the SHA-pinning policy: PyPA officially

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -87,12 +87,28 @@ When splitting a large piece of work into focused issues, keep the umbrella open
 ### Flow
 1. `make release-patch` (or `-minor` / `-major`) on `main`
 2. This runs: `hatch version` → `git commit` → `make changelog` → `git commit` → `git tag` → `git push`
-3. Tag push triggers **Publish to PyPI** GitHub Actions workflow automatically.
+3. Tag push triggers the **Publish to PyPI** GitHub Actions workflow. **Verification is a pre-publish gate, not a post-publish check.** The `publish` job runs only after `build → lib-tests → db-runtime-gate → verify-azure-certification` all pass, and it uploads the exact artifact that was tested (it never rebuilds).
+
+### Tiered runtime verification (what gates a release)
+
+Release verification is layered; each tier catches a different failure class, and **every tier is a pre-publish gate**:
+
+| Tier | Runs where | Catches |
+| --- | --- | --- |
+| `lib-tests` | publish-pypi.yml (per publish) | library unit regressions |
+| `db-runtime-gate` | publish-pypi.yml (per publish) | installs the candidate wheel, asserts the installed version matches the release, then boots Azurite and runs the package-native `BlobCheckpointStore` live integration test (`tests/integration/test_checkpoint_store_live.py`). Unlike a host-boot smoke, this imports and exercises this package's own primary runtime surface (checkpoint persistence) against a real storage backend, no cloud. |
+| `verify-azure-certification` | publish-pypi.yml (per publish) | requires a fresh, SHA+version-matched **real-Azure** certification for the exact release commit |
+| Azure Release Certification (`e2e-azure.yml`) | `workflow_dispatch`, per release | cloud-only drift — deploys to real Azure, runs live e2e, records a certification artifact. **Certified per release, not per publish.** |
+
 4. **Verify the release against the dogfood cookbook.** Once **Publish to PyPI** succeeds, confirm the downstream consumer still passes on the freshly published version:
    - In [`azure-functions-cookbook-python`](https://github.com/yeongseon/azure-functions-cookbook-python), upgrade to the new release (`hatch run pip install -U "azure-functions-db>=X.Y,<1"`) and run `make test`.
    - Treat any new `RuntimeWarning`/`DeprecationWarning` surfaced by this library during the cookbook run as a release-blocking signal — decorator-order and API-drift problems are reported as warnings, so a clean run (zero warnings from this package) is part of the release gate.
    - If the cookbook pins a lower bound (`azure-functions-db>=X.Y,<1`), bump it to the new minor in the same verification PR so examples are tested against the version they advertise.
    - A release is **not** considered done until the cookbook passes on the published version.
+5. **Real-Azure certification (required once per release, before the final tag).** Before pushing the release tag, dispatch the **Azure Release Certification** workflow on the exact release commit and version:
+   - `gh workflow run e2e-azure.yml --ref main -f ref=<release-sha> -f version=<x.y.z>`
+   - The run deploys to real Azure, executes the live e2e suite, and uploads the `azure-cert` artifact (keyed by commit SHA + version).
+   - `verify-azure-certification` in `publish-pypi.yml` later requires a successful, SHA+version-matched, non-stale (<14 day) certification for the release commit; without it the publish gate fails and the version stays unpublished.
 
 ## Branch Hygiene
 


### PR DESCRIPTION
## Context

Ports the tiered pre-publish runtime verification gate (piloted on `azure-functions-validation`, #301/#302) to this repo, adapted to db's native runtime surface. Part of the toolkit-wide rollout (umbrella: validation#308). Vendored per-repo — no reusable workflow.

Goal: no version reaches PyPI without runtime verification, and each release is certified against real Azure at least once.

## What changed

**`publish-pypi.yml`** — restructured the single `build-and-publish` job into a verify-before-publish gate:

`build → lib-tests → db-runtime-gate → verify-azure-certification → publish`

- The `publish` job uploads the **exact artifact that was tested** and never rebuilds.
- **`db-runtime-gate`** is the package-native runtime proof (per the Package Runtime Gate contract): installs the candidate wheel, asserts installed version == release version, boots Azurite, then runs the native `BlobCheckpointStore` live test (`tests/integration/test_checkpoint_store_live.py`). Unlike a host-boot smoke, this actually imports and exercises this package's own primary runtime surface (checkpoint persistence) against a real storage backend — no cloud. This is *stronger* than the validation pilot's `cookbook-host-smoke`.
- **`verify-azure-certification`** requires a fresh (<14d), SHA+version-matched real-Azure certification for the exact release commit.

**`e2e-azure.yml`** — retrofitted the existing structure to become the certification producer:
- `workflow_dispatch`-only with `ref`/`version` inputs (removed `push:tags` + `schedule` so it no longer races the publish).
- Records `cert/certification.json` (package/version/commit/ref/run_id/result/certified_at, with a version-mismatch guard) and uploads it as the `azure-cert` artifact after live e2e passes.

**`AGENTS.md`** — documents the tiered gate and the per-release real-Azure certification step.

## Acceptance Checklist

- [x] `publish-pypi.yml` job graph: `publish` needs `[build, lib-tests, db-runtime-gate, verify-azure-certification]`
- [x] Publish uploads the tested artifact (no rebuild)
- [x] `db-runtime-gate` asserts candidate version and runs the native Azurite live test
- [x] `e2e-azure.yml` is dispatch-only and emits a matching `azure-cert` record
- [x] All three files YAML-validated
- [ ] First real exercise happens on the next release tag (gate jobs are tag-triggered)

## Out of scope

- Package-native HTTP e2e for other tiers — n/a for db (db's runtime surface is checkpoint/storage, covered here).
- Phase B/C repos (langgraph, durable-graph, knowledge; drift lint) — tracked in the umbrella.

## References

- Umbrella: yeongseon/azure-functions-validation#308
- Pilot: yeongseon/azure-functions-validation#301, #302
- Honest-rename precedent: yeongseon/azure-functions-validation#309