### PR TITLE
fix: remove fragile hatch sources config and gate publish on wheel import

### DIFF
--- a/.github/workflows/publish-pypi.yml
+++ b/.github/workflows/publish-pypi.yml
@@ -59,6 +59,22 @@ jobs:
           pip install hatch
           hatch build --clean
 
+      - name: Verify built wheel is non-empty and importable
+        run: |
+          set -euo pipefail
+          WHEEL=$(ls dist/*.whl)
+          echo "Inspecting $WHEEL"
+          MODCOUNT=$(python -c "import zipfile,sys; z=zipfile.ZipFile(sys.argv[1]); print(len([n for n in z.namelist() if n.endswith('.py')]))" "$WHEEL")
+          echo "Wheel contains $MODCOUNT .py modules"
+          if [ "$MODCOUNT" -eq 0 ]; then
+            echo "::error ::Built wheel is EMPTY (0 .py modules) — refusing to publish"
+            exit 1
+          fi
+          python -m venv /tmp/verify-wheel
+          /tmp/verify-wheel/bin/pip install --upgrade pip
+          /tmp/verify-wheel/bin/pip install "$WHEEL"
+          /tmp/verify-wheel/bin/python -c "import azure_functions_db; print('import OK', azure_functions_db.__version__)"
+
       - name: Publish to PyPI
         # Documented exception to the SHA-pinning policy: PyPA officially
         # recommends pinning to the rolling `release/v1` branch. See

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -72,9 +72,6 @@ docs = [
 requires = ["hatchling"]
 build-backend = "hatchling.build"
 
-[tool.hatch.build]
-sources = ["src"]
-
 [tool.hatch.build.targets.wheel]
 packages = ["src/azure_functions_db"]
 


### PR DESCRIPTION
Closes #238

## Context

`pyproject.toml` combines a global `[tool.hatch.build] sources = ["src"]` with a prefixed wheel target `[tool.hatch.build.targets.wheel] packages = ["src/azure_functions_db"]`. That combination makes `python -m build` emit an **empty wheel** (only `*.dist-info`, zero `.py` modules) — the exact root cause behind the live `azure-functions-langgraph==0.8.1` and `azure-functions-scaffold==0.6.4` incidents.

`azure-functions-db` is currently protected **only** because `publish-pypi.yml` builds with `hatch build --clean` rather than `python -m build`. The config itself is still fragile: any change to the build command, or a contributor running `python -m build` locally, would silently ship an unimportable wheel. This removes the latent hazard (defense-in-depth).

## Changes

- **`pyproject.toml`** — remove the global `[tool.hatch.build] sources = ["src"]` block, keeping only the prefixed wheel `packages` target. Both `hatch build` and `python -m build` now emit the full 28-module wheel.
- **`publish-pypi.yml`** — add a pre-publish gate after the build step that (1) fails if the built wheel has zero `.py` modules and (2) installs the wheel in a clean venv and imports `azure_functions_db`.

## Verification

- `python -m build` → `28 py modules` (previously empty with `python -m build`)
- clean venv `pip install dist/*.whl` + `import azure_functions_db` → OK

## References

- Sibling fixes: yeongseon/azure-functions-langgraph-python#311, yeongseon/azure-functions-scaffold-python#222, yeongseon/azure-functions-knowledge-python#58
