### PR TITLE
test(security): assert connection strings are never logged

### DIFF
--- a/tests/test_shared_core.py
+++ b/tests/test_shared_core.py
@@ -215,6 +215,53 @@ class TestEngineProvider:
         with pytest.raises(ConfigurationError, match="connect_args"):
             provider.get_engine(config)
 
+    def test_engine_creation_never_logs_connection_secret(
+        self, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """A connection URL embeds credentials; engine construction must never
+        emit them to logs (regression guard for accidental credential leakage)."""
+        import logging
+
+        secret = "s3cr3t-P@ssw0rd-DO-NOT-LOG"  # noqa: S105 - test fixture, not a real secret
+        config = DbConfig(
+            connection_url=f"postgresql+psycopg2://user:{secret}@dbhost:5432/appdb"
+        )
+        provider = EngineProvider()
+        # Whether the psycopg2 driver is installed (engine builds lazily) or
+        # absent (create_engine raises ModuleNotFoundError), the embedded
+        # credential must never reach log output.
+        with caplog.at_level(logging.DEBUG):
+            try:
+                provider.get_engine(config)
+            except Exception:
+                pass
+        try:
+            assert secret not in caplog.text
+            for record in caplog.records:
+                assert secret not in record.getMessage()
+        finally:
+            provider.dispose_all()
+
+    def test_engine_creation_failure_never_logs_connection_secret(
+        self, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """Even when engine construction fails on a malformed URL, the embedded
+        credential must not surface in log output."""
+        import logging
+
+        secret = "s3cr3t-P@ssw0rd-DO-NOT-LOG"  # noqa: S105 - test fixture, not a real secret
+        config = DbConfig(
+            connection_url=f"no-such-dialect://user:{secret}@dbhost:5432/appdb"
+        )
+        provider = EngineProvider()
+        with caplog.at_level(logging.DEBUG):
+            with pytest.raises(Exception):  # noqa: B017 - SQLAlchemy plugin-load error
+                provider.get_engine(config)
+        assert secret not in caplog.text
+        for record in caplog.records:
+            assert secret not in record.getMessage()
+        provider.dispose_all()
+
     def test_connect_args_error_message_directs_to_dbconfig_connect_args(
         self, tmp_path: Path
     ) -> None:


### PR DESCRIPTION
## Summary
- Add two regression tests to `TestEngineProvider` asserting that a credential embedded in a `DbConfig.connection_url` never reaches log output:
  - success/lazy path (driver present or missing) and
  - malformed-dialect failure path.
- Both capture at `DEBUG` across all loggers and assert the secret substring appears in neither `caplog.text` nor any individual record message.

## Context
Hardening guard requested by the toolkit-wide security audit (LOW). No production code change — current behavior is already safe; this locks it in.

## Verification
- `hatch run pytest` — all pass, coverage 95.65% (≥95% gate).
- `make lint` / `make typecheck` — clean.

Closes #274