### PR TITLE
build(deps): add Dependabot cooldown to age new releases

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,6 +4,15 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+    # Let freshly-published versions age before Dependabot proposes them, so a
+    # compromised release has time to be yanked/flagged (supply-chain hardening).
+    cooldown:
+      default-days: 7
+      semver-major-days: 30
+      semver-minor-days: 7
+      semver-patch-days: 3
+      include:
+        - "*"
     commit-message:
       prefix: "chore(deps)"
     labels:
@@ -21,6 +30,15 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+    # Let freshly-published versions age before Dependabot proposes them, so a
+    # compromised release has time to be yanked/flagged (supply-chain hardening).
+    cooldown:
+      default-days: 7
+      semver-major-days: 30
+      semver-minor-days: 7
+      semver-patch-days: 3
+      include:
+        - "*"
     commit-message:
       prefix: "chore(deps)"
     labels:


### PR DESCRIPTION
## Context
Closes #275 (child of umbrella supply-chain hardening tracker). Dependabot proposes dependency updates the moment a new version is published, so a compromised or malicious release would surface in an update PR before the ecosystem can yank or flag it.

## What changed
- `.github/dependabot.yml`: added a `cooldown` block to **both** the `pip` and `github-actions` update entries:
  - `semver-major-days: 30`, `semver-minor-days: 7`, `semver-patch-days: 3`, `default-days: 7`
  - `include: ["*"]` — applies to all dependencies.

## Rationale
- Real supply-chain compromises on new **major** releases typically take 2–4 weeks to be detected and yanked, so majors are held 30 days; patches (usually fixes) age only 3.
- `cooldown` applies to **version** updates only, **not** security updates — genuine vulnerability fixes remain immediate.
- Schema validated against the [official Dependabot options reference](https://docs.github.com/en/code-security/reference/supply-chain-security/dependabot-options-reference).

Part of the umbrella #335 rollout; mirrors the approved pilot (doctor #339).