### PR TITLE
ci(deps): add non-blocking azure-functions 2.x compat lane

### DIFF
--- a/.github/workflows/ci-test.yml
+++ b/.github/workflows/ci-test.yml
@@ -126,3 +126,65 @@ jobs:
           sudo apt-get update -qq
           sudo apt-get install -y -qq shellcheck
           shellcheck examples/postgresql-poll-trigger/smoke.sh examples/mysql-poll-trigger/smoke.sh
+
+  # azure-functions 2.x compatibility proof lane (issue #287), following the
+  # sibling proof-lane pattern (azure-functions-openapi #508/#525,
+  # azure-functions-langgraph #350, azure-functions-validation #348). This is a
+  # SINGLE representative 2.x lane, not a matrix: it builds a WHEEL, installs it,
+  # then deliberately overrides the pyproject `<2.0.0` cap to pull
+  # `azure-functions>=2,<3` on Python 3.13 and runs the full suite against the
+  # 2.x SDK. This package is a runtime consumer of `azure-functions`
+  # (input/output/client injection, poll-based pseudo trigger), so binding-type
+  # behaviour under the 2.x worker is the risk surface this lane exercises.
+  #
+  # Gating decision: this lane runs on every PR as a VISIBLE compatibility
+  # signal, but it is intentionally NOT a required check -- the runtime cap stays
+  # `<2.0.0` until 2.x is certified on real Azure via e2e-azure.yml, so making
+  # this blocking before that certification would gate merges on an uncertified
+  # runtime. Promote it to a required check via branch protection once the cap is
+  # lifted. azure-functions 2.x declares Requires-Python >=3.13, so this lane
+  # pins Python 3.13.
+  azure-functions-2x:
+    name: azure-functions 2.x compat (Py 3.13)
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      - name: Set up Python 3.13
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
+        with:
+          python-version: "3.13"
+
+      - name: Build wheel
+        # Prove 2.x against a WHEEL-installed build, not an editable/source tree,
+        # mirroring the sibling proof lanes. Building the distribution artifact
+        # also avoids Hatch's default env, which is pinned to Python 3.10 in
+        # pyproject and cannot install azure-functions 2.x (Requires-Python
+        # >=3.13).
+        run: |
+          python -m pip install --upgrade pip build
+          python -m build --wheel --outdir dist
+
+      - name: Install wheel with dev extras
+        run: pip install "$(ls dist/azure_functions_db-*.whl)[dev]"
+
+      - name: Upgrade azure-functions to the 2.x line
+        # pyproject caps azure-functions <2.0.0 until 2.x is certified on real
+        # Azure. This lane deliberately overrides that cap to PROVE the package
+        # (binding decorators, poll trigger, writer injection) still builds and
+        # passes its suite under 2.x. pip warns about the intentional override;
+        # that is expected.
+        run: pip install "azure-functions>=2,<3"
+
+      - name: Show resolved versions
+        run: pip show azure-functions sqlalchemy pydantic | grep -E '^(Name|Version):'
+
+      - name: Run compat suite against the wheel + azure-functions 2.x
+        # Compatibility smoke only: `--no-cov` disables the coverage gate for this
+        # pinned run (a separate job from the coverage-enforcing matrix). The repo
+        # pytest config sets `pythonpath = ["src", "."]`, which would shadow the
+        # installed wheel with the source tree. We drop `src` (so the
+        # wheel-installed package is genuinely exercised) but keep the repo root
+        # `.` on the path for conftest/fixtures.
+        run: pytest tests/ --no-cov -q -o "pythonpath=."

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,7 +24,11 @@ classifiers = [
 
 dependencies = [
     # Cap below 2.0.0: azure-functions v2 may change worker function-indexing
-    # behavior the toolkit relies on. See knowledge#46 / dx#8.
+    # behavior the toolkit relies on, and 2.x drops Python < 3.13. See
+    # knowledge#46 / dx#8. Cap-lift criteria (issue #287): (1) the non-blocking
+    # "azure-functions 2.x compat (Py 3.13)" lane in ci-test.yml is green, and
+    # (2) 2.x is certified on real Azure via e2e-azure.yml. Lifting the cap is a
+    # separate follow-up; do not raise it here.
     "azure-functions>=1.22.0,<2.0.0",
     "sqlalchemy>=2.0",
     "azure-storage-blob>=12.21.0",


### PR DESCRIPTION
## Context
Closes #287. Adds an azure-functions 2.x compatibility proof lane so we can prove 2.x readiness before ever lifting the `<2.0.0` cap, replicating the fleet proof-lane pattern (openapi #508/#525, langgraph #350, validation #348). `azure-functions` 2.2.0 requires Python >= 3.13.

## What changed
- **`.github/workflows/ci-test.yml`** — new `azure-functions-2x` job (`name: azure-functions 2.x compat (Py 3.13)`):
  - Builds a **wheel** (`python -m build`), installs it with `[dev]` extras (exercises the built artifact, not the source tree — also sidesteps the Python-3.10-pinned Hatch env).
  - Deliberately overrides the cap: `pip install "azure-functions>=2,<3"`.
  - Runs the full suite on Python 3.13 with `--no-cov` and `pythonpath=.` (drops `src` so the wheel is genuinely exercised).
- **`pyproject.toml`** — documents the cap-lift criteria on the `azure-functions` pin. **Cap is NOT lifted.**

## Gating
Intentionally **non-blocking / informational** — this job is deliberately **not** a required check. It stays a visible signal until 2.x is certified on real Azure via `e2e-azure.yml`; promote it to a required check (and lift the cap in a separate follow-up PR) only after that certification.

## Acceptance checklist (#287)
- [x] CI lane installs `azure-functions` 2.x (wheel) on Python 3.13 and runs the full test suite.
- [x] Interpreter-branch approach (2.x only on Python 3.13; matrix <= 3.12 stays on 1.x).
- [x] Lane is non-blocking (informational) — not a required check.
- [x] Cap-lift criteria documented in `pyproject.toml`.
- [x] Does **not** lift `<2.0.0` (separate follow-up).

## Out of scope
- Removing the `<2.0.0` cap (separate PR once this lane is green and 2.x is real-Azure certified).