### PR TITLE
ci(release): produce SHA+version-matched azure-cert artifact in e2e-azure

### DIFF
--- a/.github/workflows/e2e-azure.yml
+++ b/.github/workflows/e2e-azure.yml
@@ -2,6 +2,15 @@ name: e2e-azure
 
 on:
   workflow_dispatch:
+    inputs:
+      ref:
+        description: Release commit SHA (or ref) to certify
+        required: false
+        type: string
+      version:
+        description: Expected package version (must match source __version__)
+        required: false
+        type: string
   schedule:
     - cron: "0 6 * * 1"  # Weekly on Monday 6:00 UTC
   push:
@@ -46,6 +55,10 @@ jobs:
 
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          # Certify the exact release commit when dispatched with `ref`; fall back
+          # to the triggering ref for tag pushes / scheduled runs.
+          ref: ${{ inputs.ref || github.ref }}
 
       - name: Compute resource names
         id: names
@@ -126,6 +139,44 @@ jobs:
         run: pytest tests/e2e -v -m azure_e2e --no-cov --html=e2e-report/report.html --self-contained-html
         env:
           E2E_BASE_URL: https://${{ steps.names.outputs.app }}.azurewebsites.net
+
+      - name: Record certification
+        # Produce the SHA+version-matched certification record that
+        # publish-pypi.yml's verify-azure-certification gate requires. Mirrors the
+        # sibling pattern in azure-functions-openapi's e2e-azure.yml. Runs only
+        # after the live e2e suite above has passed, so the record attests a real
+        # deploy + live-e2e success for this exact commit.
+        run: |
+          SHA=$(git rev-parse HEAD)
+          FILE_VERSION=$(grep -Po '(?<=__version__ = ")[^"]*' src/azure_functions_db/__init__.py)
+          REQ_VERSION="${{ inputs.version }}"
+          if [ -n "$REQ_VERSION" ] && [ "$REQ_VERSION" != "$FILE_VERSION" ]; then
+            echo "::error ::Requested certification version ($REQ_VERSION) != source version ($FILE_VERSION)"
+            exit 1
+          fi
+          VERSION="${REQ_VERSION:-$FILE_VERSION}"
+          mkdir -p cert
+          cat > cert/certification.json <<EOF
+          {
+            "package": "azure-functions-db",
+            "version": "$VERSION",
+            "commit": "$SHA",
+            "ref": "${{ inputs.ref || github.ref }}",
+            "workflow": "e2e-azure.yml",
+            "run_id": "${{ github.run_id }}",
+            "result": "success",
+            "certified_at": "$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+          }
+          EOF
+          cat cert/certification.json
+
+      - name: Upload certification record
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        with:
+          name: azure-cert
+          path: cert/
+          if-no-files-found: error
+          retention-days: 30
 
       - name: Upload e2e report
         if: always()

--- a/tests/test_release_workflow_pins.py
+++ b/tests/test_release_workflow_pins.py
@@ -87,3 +87,49 @@ def test_parses_block_style_needs() -> None:
         body += f"      - {item}\n"
     body += "    runs-on: ubuntu-latest\n"
     assert lint_mod.check_publish_needs(body, "publish-pypi.yml") == []
+
+
+# --- e2e-azure certification-artifact guards -------------------------------
+#
+# publish-pypi.yml's verify-azure-certification gate downloads the `azure-cert`
+# artifact and asserts cert/certification.json matches the release commit +
+# version. Nothing else guards that e2e-azure.yml actually PRODUCES that
+# artifact, so a well-meaning edit could silently break every release. These
+# text-based checks (dependency-free, mirroring the lint's style) keep the
+# producer and consumer in lockstep.
+
+_E2E_AZURE = _REPO_ROOT / ".github" / "workflows" / "e2e-azure.yml"
+
+
+def _e2e_azure_text() -> str:
+    return _E2E_AZURE.read_text(encoding="utf-8")
+
+
+def test_e2e_azure_uploads_azure_cert_artifact() -> None:
+    """The cert consumer (publish gate) needs e2e-azure to upload `azure-cert`."""
+    text = _e2e_azure_text()
+    assert "name: azure-cert" in text, (
+        "e2e-azure.yml must upload an `azure-cert` artifact; "
+        "publish-pypi.yml's verify-azure-certification gate depends on it."
+    )
+    assert "cert/certification.json" in text, (
+        "e2e-azure.yml must write cert/certification.json (the record the "
+        "publish gate parses)."
+    )
+
+
+def test_e2e_azure_exposes_ref_and_version_inputs() -> None:
+    """AGENTS.md dispatches `-f ref=... -f version=...`; the inputs must exist."""
+    text = _e2e_azure_text()
+    for token in ("workflow_dispatch:", "      ref:", "      version:"):
+        assert token in text, f"e2e-azure.yml is missing dispatch input marker: {token!r}"
+
+
+def test_e2e_azure_certification_records_required_fields() -> None:
+    """The record must carry the fields the publish gate asserts on."""
+    text = _e2e_azure_text()
+    for field in ('"commit":', '"version":', '"result":'):
+        assert field in text, (
+            f"cert/certification.json is missing required field {field!r} "
+            "asserted by publish-pypi.yml verify-azure-certification."
+        )


### PR DESCRIPTION
## Context
Part of #257. The `verify-azure-certification` gate in `publish-pypi.yml` downloads an **`azure-cert`** artifact and asserts `cert/certification.json` matches the release commit + version + freshness. But `e2e-azure.yml` **never produced that artifact**, so the gate could only ever fail with `Artifact not found for name: azure-cert` — even once Azure secrets are configured. The workflow also lacked the `ref`/`version` `workflow_dispatch` inputs that AGENTS.md's own release command (`gh workflow run e2e-azure.yml -f ref=<sha> -f version=<x.y.z>`) assumes.

This is the **workflow-side** unblock for #257, done "the way openapi does it." The Azure secrets + federated credential remain a separate human/Azure-admin step.

## What changed
Ported the proven certification mechanism from the sibling `azure-functions-openapi` `e2e-azure.yml`, **preserving this repo's existing deploy specifics** (npm Core Tools install, `--build remote`):

- **`ref` / `version` `workflow_dispatch` inputs**, and checkout of the certified commit (`ref: ${{ inputs.ref || github.ref }}`).
- **"Record certification"** step — validates the requested `version` against source `__version__`, then writes `cert/certification.json` (`package`/`version`/`commit`/`ref`/`workflow`/`run_id`/`result`/`certified_at`). Runs only **after** the live e2e suite passes.
- **"Upload certification record"** → `azure-cert` artifact (`if-no-files-found: error`).
- **Regression guards** in `tests/test_release_workflow_pins.py` (dependency-free, text-based) asserting e2e-azure keeps producing `azure-cert`, exposes the dispatch inputs, and records the fields the publish gate parses — keeping producer/consumer in lockstep.

## Verification
- `make check` clean (81 files, ruff + mypy strict).
- `pytest tests/test_release_workflow_pins.py` → 11 passed (8 existing + 3 new guards).
- YAML parses; `deploy_and_test` step order: … → Run e2e tests → Record certification → Upload certification record → Upload e2e report.

## Still human-gated (out of scope here)
- Adding `AZURE_CLIENT_ID` / `AZURE_TENANT_ID` / `AZURE_SUBSCRIPTION_ID` secrets.
- Federated-credential (OIDC) trust on the app registration.
- Actually dispatching e2e-azure + re-running publish for v0.5.2.