### PR TITLE
ci(e2e): add missing infra/main.bicep for real-Azure deploy

### DIFF
--- a/infra/main.bicep
+++ b/infra/main.bicep
@@ -1,0 +1,146 @@
+// infra/main.bicep
+// Minimal Azure resources for e2e testing.
+// Creates: Storage Account + Function App on a Flex Consumption (FC1) plan,
+// Linux/Python, version selectable via the pythonVersion parameter (default 3.10).
+// Optionally creates Application Insights (enableAppInsights=true).
+//
+// Flex Consumption (not the classic Y1 Consumption plan) is required because
+// Python 3.13+ is only available on Flex Consumption / Premium / Dedicated —
+// the classic Linux Consumption plan tops out at Python 3.12.
+// See https://learn.microsoft.com/azure/azure-functions/functions-versions?pivots=programming-language-python
+//
+// Usage:
+//   az deployment group create -g <rg> -f infra/main.bicep \
+//     -p functionAppName=<name> storageName=<name> location=<loc> pythonVersion=3.13
+
+@description('Azure region for all resources (must support Flex Consumption).')
+param location string = resourceGroup().location
+
+@description('Name of the Function App (must be globally unique).')
+param functionAppName string
+
+@description('Name of the Storage Account (3-24 lowercase alphanumeric).')
+param storageName string
+
+@description('Enable Application Insights (set true for logging e2e).')
+param enableAppInsights bool = false
+
+@description('Name of the Application Insights instance (used when enableAppInsights=true).')
+param appInsightsName string = '${functionAppName}-ai'
+
+@description('Python runtime version for the Flex Consumption Function App (e.g. 3.10, 3.13).')
+param pythonVersion string = '3.10'
+
+@description('Per-instance memory (MB) for the Flex Consumption app.')
+param instanceMemoryMB int = 2048
+
+@description('Maximum number of instances the app can scale out to (Flex minimum is 40).')
+param maximumInstanceCount int = 40
+
+// Name of the blob container that holds the deployment (.zip) package.
+var deploymentContainerName = 'app-package'
+
+// ── Storage Account ────────────────────────────────────────────────────────
+resource storageAccount 'Microsoft.Storage/storageAccounts@2023-01-01' = {
+  name: storageName
+  location: location
+  sku: { name: 'Standard_LRS' }
+  kind: 'StorageV2'
+  properties: {
+    minimumTlsVersion: 'TLS1_2'
+    allowBlobPublicAccess: false
+  }
+}
+
+resource blobService 'Microsoft.Storage/storageAccounts/blobServices@2023-01-01' = {
+  parent: storageAccount
+  name: 'default'
+}
+
+// Deployment package container required by the Flex Consumption plan.
+resource deploymentContainer 'Microsoft.Storage/storageAccounts/blobServices/containers@2023-01-01' = {
+  parent: blobService
+  name: deploymentContainerName
+}
+
+var storageConnectionString = 'DefaultEndpointsProtocol=https;AccountName=${storageAccount.name};EndpointSuffix=${environment().suffixes.storage};AccountKey=${storageAccount.listKeys().keys[0].value}'
+
+// ── App Insights (optional) ────────────────────────────────────────────────
+resource appInsights 'Microsoft.Insights/components@2020-02-02' = if (enableAppInsights) {
+  name: appInsightsName
+  location: location
+  kind: 'web'
+  properties: {
+    Application_Type: 'web'
+    RetentionInDays: 30
+  }
+}
+
+// ── Flex Consumption Hosting Plan ──────────────────────────────────────────
+resource hostingPlan 'Microsoft.Web/serverfarms@2024-04-01' = {
+  name: '${functionAppName}-plan'
+  location: location
+  sku: {
+    name: 'FC1'
+    tier: 'FlexConsumption'
+  }
+  kind: 'functionapp'
+  properties: {
+    reserved: true
+  }
+}
+
+// ── Function App (Flex Consumption) ────────────────────────────────────────
+resource functionApp 'Microsoft.Web/sites@2024-04-01' = {
+  name: functionAppName
+  location: location
+  kind: 'functionapp,linux'
+  dependsOn: [ deploymentContainer ]
+  properties: {
+    serverFarmId: hostingPlan.id
+    httpsOnly: true
+    functionAppConfig: {
+      deployment: {
+        storage: {
+          type: 'blobContainer'
+          value: '${storageAccount.properties.primaryEndpoints.blob}${deploymentContainerName}'
+          authentication: {
+            type: 'StorageAccountConnectionString'
+            storageAccountConnectionStringName: 'DEPLOYMENT_STORAGE_CONNECTION_STRING'
+          }
+        }
+      }
+      scaleAndConcurrency: {
+        instanceMemoryMB: instanceMemoryMB
+        maximumInstanceCount: maximumInstanceCount
+      }
+      runtime: {
+        name: 'python'
+        version: pythonVersion
+      }
+    }
+    siteConfig: {
+      appSettings: concat(
+        [
+          { name: 'AzureWebJobsStorage', value: storageConnectionString }
+          { name: 'DEPLOYMENT_STORAGE_CONNECTION_STRING', value: storageConnectionString }
+        ],
+        enableAppInsights
+          ? [
+              {
+                name: 'APPLICATIONINSIGHTS_CONNECTION_STRING'
+                value: appInsights.properties.ConnectionString
+              }
+            ]
+          : []
+      )
+    }
+  }
+}
+
+// ── Outputs ────────────────────────────────────────────────────────────────
+output functionAppName string = functionApp.name
+output defaultHostName string = functionApp.properties.defaultHostName
+output appInsightsConnectionString string = enableAppInsights
+  ? appInsights.properties.ConnectionString
+  : ''

--- a/tests/test_release_workflow_pins.py
+++ b/tests/test_release_workflow_pins.py
@@ -133,3 +133,18 @@ def test_e2e_azure_certification_records_required_fields() -> None:
             f"cert/certification.json is missing required field {field!r} "
             "asserted by publish-pypi.yml verify-azure-certification."
         )
+
+
+def test_e2e_azure_bicep_template_exists() -> None:
+    """The deploy step runs `az deployment group create --template-file
+    infra/main.bicep`; that file must exist and be referenced, or the real-Azure
+    deploy (and thus certification) fails before it can produce `azure-cert`."""
+    text = _e2e_azure_text()
+    assert "--template-file infra/main.bicep" in text, (
+        "e2e-azure.yml must deploy infra via `--template-file infra/main.bicep`."
+    )
+    bicep = _REPO_ROOT / "infra" / "main.bicep"
+    assert bicep.is_file(), (
+        "infra/main.bicep is referenced by e2e-azure.yml's Deploy infra step "
+        "but is missing; the real-Azure deploy cannot run without it."
+    )


### PR DESCRIPTION
## Context
Part of #257 (unblock v0.5.2 real-Azure certification). While wiring db into the fleet Azure OIDC app registration and dispatching `e2e-azure.yml`, the **Deploy infra (Bicep)** step failed:

```
ERROR: An error occurred reading file. Could not find a part of the path '.../infra/main.bicep'.
```

`e2e-azure.yml` was ported from `azure-functions-openapi-python` but its `infra/main.bicep` template was **never committed**. The deploy path has therefore never actually run — prior `e2e-azure` "success" runs skipped `deploy_and_test` because the `AZURE_*` secrets were absent (the `check_secrets` gate short-circuited the job). Now that the secrets and federated credentials are in place, the missing template surfaces.

## Change
- Add `infra/main.bicep`, ported verbatim from openapi's proven template (Storage Account + Function App on a Flex Consumption `FC1` plan, optional App Insights). It is fully generic — no openapi-specific content — and its params (`location`, `functionAppName`, `storageName`, `enableAppInsights`) already match db's workflow deploy call.
- Add a regression guard in `tests/test_release_workflow_pins.py` asserting the workflow-referenced `infra/main.bicep` exists, keeping producer/consumer in lockstep.

## Verification
- `hatch run pytest tests/test_release_workflow_pins.py --no-cov` → 12 passed.

## Note (follow-up, not in this PR)
The `verify-azure-certification` gate certifies the **exact release commit**. The v0.5.2 tag commit predates this fix, so certifying v0.5.2 will require either re-tagging v0.5.2 onto post-fix `main` or cutting a new patch — a release-level decision tracked in #257.

Refs #257