### PR TITLE
ci(e2e): provision Postgres Flexible Server as e2e database

### DIFF
--- a/.github/workflows/e2e-azure.yml
+++ b/.github/workflows/e2e-azure.yml
@@ -71,6 +71,9 @@ jobs:
           echo "rg=${RG}"   >> "$GITHUB_OUTPUT"
           echo "app=${APP}" >> "$GITHUB_OUTPUT"
           echo "st=${ST}"   >> "$GITHUB_OUTPUT"
+          PG="pg-af-e2e-${REPO_SHORT}-${RUN}"
+          PG="${PG:0:63}"
+          echo "pg=${PG}"   >> "$GITHUB_OUTPUT"
 
       - name: Azure login (OIDC)
         uses: azure/login@f5d393ae46f8fde4be8b75f32e3fc50e654ad0ca # v3.0.1
@@ -86,6 +89,15 @@ jobs:
             --location "$AZURE_LOCATION" \
             --tags purpose=e2e repo=azure-functions-db-python run="${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}"
 
+      - name: Generate Postgres password
+        id: pgpw
+        run: |
+          # 3 character classes (upper, lower, digit) + URL-safe (alphanumeric only)
+          # so it can be embedded in the SQLAlchemy connection URL without escaping.
+          PW="Pg$(openssl rand -hex 16)Az9"
+          echo "::add-mask::$PW"
+          echo "password=$PW" >> "$GITHUB_OUTPUT"
+
       - name: Deploy infra (Bicep)
         run: |
           az deployment group create \
@@ -95,7 +107,23 @@ jobs:
                 location="$AZURE_LOCATION" \
                 functionAppName="${{ steps.names.outputs.app }}" \
                 storageName="${{ steps.names.outputs.st }}" \
-                enableAppInsights=false
+                enableAppInsights=false \
+                enablePostgres=true \
+                postgresServerName="${{ steps.names.outputs.pg }}" \
+                postgresAdminPassword="${{ steps.pgpw.outputs.password }}"
+
+      - name: Configure database connection (E2E_DB_URL)
+        run: |
+          FQDN=$(az deployment group show \
+            --resource-group "${{ steps.names.outputs.rg }}" \
+            --name main \
+            --query properties.outputs.postgresFqdn.value -o tsv)
+          URL="postgresql+psycopg://e2eadmin:${{ steps.pgpw.outputs.password }}@${FQDN}:5432/e2edb?sslmode=require"
+          echo "::add-mask::$URL"
+          az functionapp config appsettings set \
+            --resource-group "${{ steps.names.outputs.rg }}" \
+            --name "${{ steps.names.outputs.app }}" \
+            --settings E2E_DB_URL="$URL" -o none
 
       - name: Set up Python 3.12
         uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0

--- a/infra/main.bicep
+++ b/infra/main.bicep
@@ -37,6 +37,22 @@ param instanceMemoryMB int = 2048
 @description('Maximum number of instances the app can scale out to (Flex minimum is 40).')
 param maximumInstanceCount int = 40
 
+@description('Provision a PostgreSQL Flexible Server as the e2e test database.')
+param enablePostgres bool = false
+
+@description('Name of the e2e PostgreSQL Flexible Server (globally unique, 3-63 lowercase).')
+param postgresServerName string = '${functionAppName}-pg'
+
+@description('Admin login for the e2e PostgreSQL Flexible Server.')
+param postgresAdminLogin string = 'e2eadmin'
+
+@description('Admin password for the e2e PostgreSQL Flexible Server (required when enablePostgres=true).')
+@secure()
+param postgresAdminPassword string = ''
+
+@description('Name of the e2e database created on the Flexible Server.')
+param postgresDatabaseName string = 'e2edb'
+
 // Name of the blob container that holds the deployment (.zip) package.
 var deploymentContainerName = 'app-package'
 
@@ -138,9 +154,57 @@ resource functionApp 'Microsoft.Web/sites@2024-04-01' = {
   }
 }
 
+// ── PostgreSQL Flexible Server (optional e2e database) ──────────────────────
+// Burstable B1ms / PG 16, with a firewall rule that allows access from Azure
+// services (the 0.0.0.0 sentinel rule) so the Flex Consumption Function App —
+// whose outbound IPs are dynamic — can reach it. SSL is required by default;
+// clients must connect with sslmode=require.
+resource postgres 'Microsoft.DBforPostgreSQL/flexibleServers@2022-12-01' = if (enablePostgres) {
+  name: postgresServerName
+  location: location
+  sku: {
+    name: 'Standard_B1ms'
+    tier: 'Burstable'
+  }
+  properties: {
+    version: '16'
+    administratorLogin: postgresAdminLogin
+    administratorLoginPassword: postgresAdminPassword
+    storage: {
+      storageSizeGB: 32
+    }
+    backup: {
+      backupRetentionDays: 7
+      geoRedundantBackup: 'Disabled'
+    }
+    highAvailability: {
+      mode: 'Disabled'
+    }
+  }
+}
+
+resource postgresDatabase 'Microsoft.DBforPostgreSQL/flexibleServers/databases@2022-12-01' = if (enablePostgres) {
+  parent: postgres
+  name: postgresDatabaseName
+}
+
+resource postgresAllowAzure 'Microsoft.DBforPostgreSQL/flexibleServers/firewallRules@2022-12-01' = if (enablePostgres) {
+  parent: postgres
+  name: 'AllowAllAzureServices'
+  properties: {
+    startIpAddress: '0.0.0.0'
+    endIpAddress: '0.0.0.0'
+  }
+}
+
 // ── Outputs ────────────────────────────────────────────────────────────────
 output functionAppName string = functionApp.name
 output defaultHostName string = functionApp.properties.defaultHostName
 output appInsightsConnectionString string = enableAppInsights
   ? appInsights.properties.ConnectionString
   : ''
+
+output postgresFqdn string = enablePostgres
+  ? postgres.properties.fullyQualifiedDomainName
+  : ''
+output postgresDatabaseName string = enablePostgres ? postgresDatabaseName : ''


### PR DESCRIPTION
## Context
Part of #257. With OIDC + the `infra/main.bicep` fix (#295) in place, `e2e-azure` now deploys and publishes successfully, but the deployed e2e app returns **HTTP 500 on `/api/setup`**: it defaults to relative-path SQLite (`sqlite:///e2e_test.db`), which is unwritable on the read-only Flex Consumption package, and no shared database was ever provisioned. The CRUD e2e (insert via `@db.output`, read back via `@db.input`) needs a real, cross-instance, writable store.

## Change
- **`infra/main.bicep`**: add an optional PostgreSQL Flexible Server (Burstable `Standard_B1ms`, PG 16) + database + an `AllowAllAzureServices` firewall rule (0.0.0.0 sentinel, so the Flex Consumption app's dynamic outbound IPs can connect). Gated behind `enablePostgres` (default `false`); exposes `postgresFqdn` output.
- **`.github/workflows/e2e-azure.yml`**:
  - compute a unique `pg-af-e2e-db-<run>` server name
  - generate a URL-safe admin password (masked)
  - pass `enablePostgres=true` + password to the deployment
  - new step wires `E2E_DB_URL=postgresql+psycopg://...@<fqdn>:5432/e2edb?sslmode=require` as an app setting **before** publish

This certifies the bindings against a real **Tier-1** database (Postgres), matching the README's promise that Tier-1 DBs are "exercised by release certification". The `psycopg[binary]` driver is already bundled via `azure-functions-db[all]`.

## Verification
- `az bicep build infra/main.bicep` → valid.
- `hatch run pytest tests/test_release_workflow_pins.py --no-cov` → 12 passed.
- Full live validation via an `e2e-azure` dispatch on the release commit (next step in #257).

Refs #257